### PR TITLE
add flex:1 to SwipeViewsHeader class in css for proper tab height

### DIFF
--- a/src/SwipeViews.css
+++ b/src/SwipeViews.css
@@ -6,6 +6,7 @@
 }
 
 .SwipeViewsHeader {
+  flex: 1;
   min-height: 40px;
   border-bottom: #F0F0F0 4px solid;
   display: flex;


### PR DESCRIPTION
I tried the library on chrome. Used dev tools for openeing mobile view. The height of SwipeViewsHeader is almost half the screen as shown in the picture below. 
![bug](https://cloud.githubusercontent.com/assets/746482/11953082/85aa9b18-a8c3-11e5-947d-46fadc926d74.png)

I solved it by adding flex:1 to SwipeViewsHeader class in SwipeViews.css
After making this fix, it looks like 
![resolution](https://cloud.githubusercontent.com/assets/746482/11953094/9bbf8e4a-a8c3-11e5-8b4a-6b7ac3f076ac.png)

Please advice,
