### PR TITLE
SwipeViewsTabs min-height 0% for getting tab indicator at accurate pl…

### DIFF
--- a/src/SwipeViews.css
+++ b/src/SwipeViews.css
@@ -14,7 +14,7 @@
 
 .SwipeViewsTabs {
   flex: 1;
-  min-height: 100%;
+  min-height: 0%;
   display: flex;
   flex-flow: column nowrap;
   margin-bottom: -4px;


### PR DESCRIPTION
SwipeViewsTabs min-height 0% for getting tab indicator at accurate place in chrome.

Screenshot with min-height: 100%
![bug](https://cloud.githubusercontent.com/assets/746482/11993580/c8d472f6-aa58-11e5-88e1-8b464fbcf600.png)

Screenshot with min-height: 0%
![resolved](https://cloud.githubusercontent.com/assets/746482/11993583/cf4afe20-aa58-11e5-9272-aa1e52872668.png)

Please advice. 
