### PR TITLE
Fix: If Number.isInteger() is not suported, create this new method.

### DIFF
--- a/src/SwipeViews.js
+++ b/src/SwipeViews.js
@@ -1,5 +1,11 @@
 import React from 'react';
 
+Number.isInteger = Number.isInteger || function(value) {
+  return typeof value === "number" && 
+    isFinite(value) && 
+    Math.floor(value) === value;
+};
+
 export default class SwipeViews extends React.Component {
 
   constructor(props) {


### PR DESCRIPTION
Older versions of WebView work's with "older" specifications of Js, which no have the method Number.isInteger(). This Fix bring more compatible with android 4.1.2 , 4.x

https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
